### PR TITLE
Sugar syntax for add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,17 @@ server.add({ cmd: 'read' }, (req, reply) => {
     }
   })
 })
+
+//or using the sugar free syntax
+server.add('write', (req, reply) => {
+  reply(null, {
+    answering: 'foo'
+  })
+})
 ```
 
 We recommend using [baseswim](http://github.com/mcollina/baseswim) to
-run a base node. It also avalailable as a tiny docker image.
+run a base node. It also available as a tiny docker image.
 
 <a name="api"></a>
 ## API
@@ -199,6 +206,21 @@ Example:
 
 ```js
 instance.add({ cmd: 'parse' }, (req, reply) => {
+  reply(null, {
+    a: 'response',
+    streams: {
+      any: stream
+    }
+  })
+})
+```
+
+For convenience a command can also be defined by a `string`.
+
+Example:
+
+```js
+instance.add('parse', (req, reply) => {
   reply(null, {
     a: 'response',
     streams: {

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -49,6 +49,31 @@ test('using the request router', { timeout: 5000 }, (t) => {
   })
 })
 
+test('use the sugar notation for pattern', { timeout: 5000 }, (t) => {
+  t.plan(2)
+
+  bootTwo(t, (i1, i2) => {
+    let i1Key = getKey(i1)
+
+    i1.request({
+      key: i1Key,
+      cmd: 'sugar',
+      value: 1
+    }, (err, response) => {
+      t.error(err, 'NO ERROR')
+      t.deepEqual(response, {
+        replying: 'i1'
+      }, 'response matches')
+    })
+
+    i1.add('sugar', (req, reply) => {
+      t.equal(req.key, i1Key, 'Match made')
+      t.equal(req.value, 1, 'Value matches')
+      reply(null, { replying: 'i1' })
+    })
+  })
+})
+
 test('not found', { timeout: 5000 }, (t) => {
   t.plan(5)
 

--- a/upring.js
+++ b/upring.js
@@ -120,6 +120,11 @@ UpRing.prototype.add = function (pattern, func) {
   if (!this._router) {
     this._router = bloomrun()
   }
+
+  if (typeof pattern === 'string') {
+    pattern = { cmd: pattern }
+  }
+
   this._router.add(pattern, func)
 }
 


### PR DESCRIPTION
Partially fixes Issue #4 

I just added a simple shortcut to define a command from a string. Probably the next iteration should include a complete pattern parser (like suggested in #3).

**cc:** @mcdonnelldean