### PR TITLE
Better tracker API. Support for tracking one replica.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "4"
-  - "5"
   - "6"
 env:
   - CXX=g++-4.8

--- a/README.md
+++ b/README.md
@@ -269,15 +269,17 @@ is completed.
 Returns `true` or `false` depending if the given key has been allocated to this node or not.
 
 <a name="track"></a>
-### instance.track(key, callback(err, newPeer))
+### instance.track(key)
 
-Track the given `key`: the given `callback` will be fired when the
+Create a new tracker for the given `key`.
+
+It will emit `'moved'` when the
 `key` exits from this peer responsibility.
 
-The callback will be called with a `newPeer` if the peers knows the
+The `'moved'` event will be called with a `newPeer` if the peers knows the
 target, with `null` otherwise, e.g. when `close` is called.
 
-Returns a `function` that can be used to remove the tracker.
+The tracker has an `end` method to quit tracking.
 
 <a name="close"></a>
 ### instance.close(cb)

--- a/README.md
+++ b/README.md
@@ -269,17 +269,27 @@ is completed.
 Returns `true` or `false` depending if the given key has been allocated to this node or not.
 
 <a name="track"></a>
-### instance.track(key)
+### instance.track(key[, opts])
 
 Create a new tracker for the given `key`.
 
-It will emit `'moved'` when the
-`key` exits from this peer responsibility.
+Options:
 
-The `'moved'` event will be called with a `newPeer` if the peers knows the
-target, with `null` otherwise, e.g. when `close` is called.
+* `replica`, turns on tracking of a replica of the given data. Default:
+  `false`.
 
-The tracker has an `end` method to quit tracking.
+Events:
+
+* `'moved'`, when the `key` exits from this peer responsibility.
+  The `'moved'` event will be called with a `newPeer` if the peers knows the
+  target, with `null` otherwise, e.g. when `close` is called.
+* `'replica'`, adds or replace the replica of the given key. The first
+  argument is the destination peer, while the second is the old replica
+  peer (if any).
+
+Methods:
+
+* `end()`, quit tracking.
 
 <a name="close"></a>
 ### instance.close(cb)

--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ Options:
 
 Events:
 
-* `'moved'`, when the `key` exits from this peer responsibility.
-  The `'moved'` event will be called with a `newPeer` if the peers knows the
+* `'move'`, when the `key` exits from this peer responsibility.
+  The `'move'` event will be called with a `newPeer` if the peers knows the
   target, with `null` otherwise, e.g. when `close` is called.
 * `'replica'`, adds or replace the replica of the given key. The first
   argument is the destination peer, while the second is the old replica

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -128,6 +128,10 @@ function build (hashring) {
         if (tracker instanceof Replica) {
           replicas.push(tracker)
         } else {
+          if (tracker.replica) {
+            tracker.replica.end()
+            tracker.replica = null
+          }
           tracker.emit('moved', event.to)
         }
       }
@@ -151,7 +155,9 @@ function build (hashring) {
     while (iterator.valid) {
       for (var i = 0; i < iterator.value.length; i++) {
         tracker = iterator.value[i]
-        tracker.emit('moved', null)
+        if (!(tracker instanceof Replica)) {
+          tracker.emit('moved', null)
+        }
       }
       iterator.next()
     }

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -7,6 +7,16 @@ const maxInt = Math.pow(2, 32) - 1
 
 function build (hashring) {
   var tree = createTree()
+  var peers = 0
+  var requestReplicas = []
+
+  hashring.on('peerUp', function () {
+    peers++
+  })
+
+  hashring.on('peerDown', function () {
+    peers--
+  })
 
   function Tracker (key, opts) {
     EE.call(this)
@@ -20,14 +30,27 @@ function build (hashring) {
     this.key = key
     this.list = addToList(this)
     this.replica = null
+    this.ended = false
 
     if (opts && opts.replica) {
-      this.replica = new Replica(this)
-
-      if (this.replica.peer) {
-        // event replica newPeer oldPeer
-        process.nextTick(this.emit.bind(this), 'replica', this.replica.peer, null)
+      if (peers > 0) {
+        addReplica(this)
+      } else {
+        requestReplicas.push(this)
       }
+    }
+  }
+
+  function addReplica (tracker) {
+    if (tracker.ended) {
+      return
+    }
+
+    tracker.replica = new Replica(tracker)
+
+    if (tracker.replica.peer) {
+      // event replica newPeer oldPeer
+      process.nextTick(tracker.emit.bind(tracker), 'replica', tracker.replica.peer, null)
     }
   }
 
@@ -35,6 +58,8 @@ function build (hashring) {
 
   Tracker.prototype.end = function () {
     removefromList(this)
+    this.ended = true
+
     const replica = this.replica
 
     if (this.replica) {
@@ -66,18 +91,20 @@ function build (hashring) {
     var result = -1
 
     for (var i = 0; i < points.length; i++) {
-      if (point < points[i]) {
+      if (point <= points[i]) {
         result = points[i] + 1
+      } else if (result > 0) {
+        break
       }
     }
 
     // cycle, if it's greater than the end
     // it is the first element
     if (result === -1) {
-      result = points[0] + 1
+      result = maxInt
     }
 
-    if (result >= maxInt) {
+    if (result > maxInt) {
       result = 0
     }
 
@@ -120,6 +147,13 @@ function build (hashring) {
     var i
     var tracker
 
+    if (requestReplicas.length > 0) {
+      for (i = 0; i < requestReplicas.length; i++) {
+        process.nextTick(addReplica, requestReplicas[i])
+      }
+      requestReplicas = []
+    }
+
     while (iterator.valid && iterator.key <= event.end) {
       for (i = 0; i < iterator.value.length; i++) {
         tracker = iterator.value[i]
@@ -131,6 +165,7 @@ function build (hashring) {
             tracker.replica.end()
             tracker.replica = null
           }
+          tracker.ended = true
           tracker.emit('move', event.to)
         }
       }
@@ -138,12 +173,21 @@ function build (hashring) {
       iterator.next()
     }
 
-    for (i = 0; i < replicas.length; i++) {
+    if (replicas.length > 0) {
+      process.nextTick(updateReplicas, replicas)
+    }
+  }
+
+  function updateReplicas (replicas) {
+    for (var i = 0; i < replicas.length; i++) {
       var prev = replicas[i]
-      tracker = prev.tracker
-      var newReplica = new Replica(tracker)
-      tracker.replica = newReplica
-      tracker.emit('replica', newReplica.peer, prev.peer)
+      var tracker = prev.tracker
+      tracker.replica = null
+      if (!tracker.ended) {
+        var newReplica = new Replica(tracker)
+        tracker.replica = newReplica
+        tracker.emit('replica', newReplica.peer, prev.peer)
+      }
     }
   }
 

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -42,17 +42,14 @@ function build (hashring) {
     }
   }
 
-  class Replica extends EE {
+  class Replica {
     constructor (tracker) {
-      super()
-
-      const next = hashring.next(tracker.key)
       const main = hashring.lookup(tracker.key)
 
+      this.key = getNextPoint(tracker.key, main.points)
       this.tracker = tracker
-      this.key = getNextPoint(tracker.key, (next || main).points)
       this.list = addToList(this)
-      this.peer = next
+      this.peer = hashring.next(tracker.key)
     }
 
     end () {
@@ -125,10 +122,11 @@ function build (hashring) {
     while (iterator.valid && iterator.key <= event.end) {
       for (var i = 0; i < iterator.value.length; i++) {
         const tracker = iterator.value[i]
-        tracker.emit('moved', event.to)
 
         if (tracker instanceof Replica) {
           replicas.push(tracker)
+        } else {
+          tracker.emit('moved', event.to)
         }
       }
       tree = iterator.remove()

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -131,7 +131,7 @@ function build (hashring) {
             tracker.replica.end()
             tracker.replica = null
           }
-          tracker.emit('moved', event.to)
+          tracker.emit('move', event.to)
         }
       }
       tree = iterator.remove()
@@ -155,7 +155,7 @@ function build (hashring) {
       for (var i = 0; i < iterator.value.length; i++) {
         tracker = iterator.value[i]
         if (!(tracker instanceof Replica)) {
-          tracker.emit('moved', null)
+          tracker.emit('move', null)
         }
       }
       iterator.next()

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -1,9 +1,45 @@
 'use strict'
 
 const createTree = require('functional-red-black-tree')
+const EE = require('events').EventEmitter
 
-function tracker (hashring) {
+function build (hashring) {
   var tree = createTree()
+
+  class Tracker extends EE {
+    constructor (key) {
+      super()
+
+      key = hashring.hash(key)
+      const list = tree.get(key) || []
+
+      this.list = list
+      this.key = key
+
+      if (!hashring.allocatedToMe(key)) {
+        throw new Error('not allocate to me')
+      }
+
+      if (list.length === 0) {
+        tree = tree.insert(key, list)
+      }
+
+      list.push(this)
+    }
+
+    end () {
+      const list = this.list
+      const i = list.indexOf(this)
+
+      if (i >= 0) {
+        list.splice(i, 1)
+      }
+
+      if (list.length === 0) {
+        tree = tree.remove(this.key)
+      }
+    }
+  }
 
   return {
     track,
@@ -11,34 +47,8 @@ function tracker (hashring) {
     clear
   }
 
-  function track (key, cb) {
-    key = hashring.hash(key)
-
-    const list = tree.get(key) || []
-
-    if (!hashring.allocatedToMe(key)) {
-      process.nextTick(cb, new Error('not allocate to me'))
-      return
-    }
-
-    if (list.length === 0) {
-      tree = tree.insert(key, list)
-    }
-
-    list.push(cb)
-
-    // untrack closure
-    return function untrack () {
-      const i = list.indexOf(cb)
-
-      if (i >= 0) {
-        list.splice(i, 1)
-      }
-
-      if (list.length === 0) {
-        tree = tree.remove(key)
-      }
-    }
+  function track (key) {
+    return new Tracker(key)
   }
 
   function check (event) {
@@ -46,8 +56,8 @@ function tracker (hashring) {
 
     while (iterator.valid && iterator.key <= event.end) {
       for (var i = 0; i < iterator.value.length; i++) {
-        const cb = iterator.value[i]
-        cb(null, event.to)
+        const tracker = iterator.value[i]
+        tracker.emit('moved', event.to)
       }
       tree = iterator.remove()
       iterator.next()
@@ -59,8 +69,8 @@ function tracker (hashring) {
 
     while (iterator.valid) {
       for (var i = 0; i < iterator.value.length; i++) {
-        const cb = iterator.value[i]
-        cb(null, null)
+        const tracker = iterator.value[i]
+        tracker.emit('moved', null)
       }
       iterator.next()
     }
@@ -69,4 +79,4 @@ function tracker (hashring) {
   }
 }
 
-module.exports = tracker
+module.exports = build

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -2,42 +2,61 @@
 
 const createTree = require('functional-red-black-tree')
 const EE = require('events').EventEmitter
+const maxInt = Math.pow(2, 32) - 1
 
 function build (hashring) {
   var tree = createTree()
 
   class Tracker extends EE {
-    constructor (key) {
+    constructor (key, opts) {
       super()
 
       key = hashring.hash(key)
-      const list = tree.get(key) || []
-
-      this.list = list
-      this.key = key
 
       if (!hashring.allocatedToMe(key)) {
         throw new Error('not allocate to me')
       }
 
-      if (list.length === 0) {
-        tree = tree.insert(key, list)
-      }
+      this.key = key
+      this.list = addToList(this)
+      this.replica = null
 
-      list.push(this)
+      if (opts && opts.replica) {
+        this.replica = new Replica(this)
+
+        if (this.replica.peer) {
+          // event changeReplica newPeer oldPeer
+          process.nextTick(this.emit.bind(this), 'changeReplica', this.replica.peer, null)
+        }
+      }
     }
 
     end () {
-      const list = this.list
-      const i = list.indexOf(this)
+      removefromList(this)
+      const replica = this.replica
 
-      if (i >= 0) {
-        list.splice(i, 1)
+      if (this.replica) {
+        this.replica = null
+        replica.end()
       }
+    }
+  }
 
-      if (list.length === 0) {
-        tree = tree.remove(this.key)
-      }
+  class Replica extends EE {
+    constructor (tracker) {
+      super()
+
+      const next = hashring.next(tracker.key)
+      const main = hashring.lookup(tracker.key)
+
+      this.tracker = tracker
+      this.key = getNextPoint(tracker.key, (next || main).points)
+      this.list = addToList(this)
+      this.peer = next
+    }
+
+    end () {
+      removefromList(this)
     }
   }
 
@@ -47,21 +66,81 @@ function build (hashring) {
     clear
   }
 
-  function track (key) {
-    return new Tracker(key)
+  function getNextPoint (point, points) {
+    var result = -1
+
+    for (var i = 0; i < points.length; i++) {
+      if (point < points[i]) {
+        result = points[i] + 1
+      }
+    }
+
+    // cycle, if it's greater than the end
+    // it is the first element
+    if (result === -1) {
+      result = points[0] + 1
+    }
+
+    if (result >= maxInt) {
+      result = 0
+    }
+
+    return result
+  }
+
+  function addToList (obj) {
+    const key = obj.key
+    const list = tree.get(key) || []
+
+    if (list.length === 0) {
+      tree = tree.insert(key, list)
+    }
+
+    list.push(obj)
+
+    return list
+  }
+
+  function removefromList (obj) {
+    const list = obj.list
+    const i = list.indexOf(obj)
+
+    if (i >= 0) {
+      list.splice(i, 1)
+    }
+
+    if (list.length === 0) {
+      tree = tree.remove(obj.key)
+    }
+  }
+
+  function track (key, opts) {
+    return new Tracker(key, opts)
   }
 
   function check (event) {
     var iterator = tree.gt(event.start)
+    const replicas = []
 
     while (iterator.valid && iterator.key <= event.end) {
       for (var i = 0; i < iterator.value.length; i++) {
         const tracker = iterator.value[i]
         tracker.emit('moved', event.to)
+
+        if (tracker instanceof Replica) {
+          replicas.push(tracker)
+        }
       }
       tree = iterator.remove()
       iterator.next()
     }
+
+    replicas.forEach((prev) => {
+      const tracker = prev.tracker
+      const newReplica = new Replica(tracker)
+      tracker.replica = newReplica
+      tracker.emit('changeReplica', newReplica.peer, prev.peer)
+    })
   }
 
   function clear () {

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -25,8 +25,8 @@ function build (hashring) {
         this.replica = new Replica(this)
 
         if (this.replica.peer) {
-          // event changeReplica newPeer oldPeer
-          process.nextTick(this.emit.bind(this), 'changeReplica', this.replica.peer, null)
+          // event replica newPeer oldPeer
+          process.nextTick(this.emit.bind(this), 'replica', this.replica.peer, null)
         }
       }
     }
@@ -117,11 +117,13 @@ function build (hashring) {
 
   function check (event) {
     var iterator = tree.gt(event.start)
-    const replicas = []
+    var replicas = []
+    var i
+    var tracker
 
     while (iterator.valid && iterator.key <= event.end) {
-      for (var i = 0; i < iterator.value.length; i++) {
-        const tracker = iterator.value[i]
+      for (i = 0; i < iterator.value.length; i++) {
+        tracker = iterator.value[i]
 
         if (tracker instanceof Replica) {
           replicas.push(tracker)
@@ -133,20 +135,22 @@ function build (hashring) {
       iterator.next()
     }
 
-    replicas.forEach((prev) => {
-      const tracker = prev.tracker
-      const newReplica = new Replica(tracker)
+    for (i = 0; i < replicas.length; i++) {
+      var prev = replicas[i]
+      tracker = prev.tracker
+      var newReplica = new Replica(tracker)
       tracker.replica = newReplica
-      tracker.emit('changeReplica', newReplica.peer, prev.peer)
-    })
+      tracker.emit('replica', newReplica.peer, prev.peer)
+    }
   }
 
   function clear () {
     var iterator = tree.gt(0)
+    var tracker
 
     while (iterator.valid) {
       for (var i = 0; i < iterator.value.length; i++) {
-        const tracker = iterator.value[i]
+        tracker = iterator.value[i]
         tracker.emit('moved', null)
       }
       iterator.next()

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -1,60 +1,59 @@
 'use strict'
 
 const createTree = require('functional-red-black-tree')
+const inherits = require('util').inherits
 const EE = require('events').EventEmitter
 const maxInt = Math.pow(2, 32) - 1
 
 function build (hashring) {
   var tree = createTree()
 
-  class Tracker extends EE {
-    constructor (key, opts) {
-      super()
+  function Tracker (key, opts) {
+    EE.call(this)
 
-      key = hashring.hash(key)
+    key = hashring.hash(key)
 
-      if (!hashring.allocatedToMe(key)) {
-        throw new Error('not allocate to me')
-      }
-
-      this.key = key
-      this.list = addToList(this)
-      this.replica = null
-
-      if (opts && opts.replica) {
-        this.replica = new Replica(this)
-
-        if (this.replica.peer) {
-          // event replica newPeer oldPeer
-          process.nextTick(this.emit.bind(this), 'replica', this.replica.peer, null)
-        }
-      }
+    if (!hashring.allocatedToMe(key)) {
+      throw new Error('not allocate to me')
     }
 
-    end () {
-      removefromList(this)
-      const replica = this.replica
+    this.key = key
+    this.list = addToList(this)
+    this.replica = null
 
-      if (this.replica) {
-        this.replica = null
-        replica.end()
+    if (opts && opts.replica) {
+      this.replica = new Replica(this)
+
+      if (this.replica.peer) {
+        // event replica newPeer oldPeer
+        process.nextTick(this.emit.bind(this), 'replica', this.replica.peer, null)
       }
     }
   }
 
-  class Replica {
-    constructor (tracker) {
-      const main = hashring.lookup(tracker.key)
+  inherits(Tracker, EE)
 
-      this.key = getNextPoint(tracker.key, main.points)
-      this.tracker = tracker
-      this.list = addToList(this)
-      this.peer = hashring.next(tracker.key)
-    }
+  Tracker.prototype.end = function () {
+    removefromList(this)
+    const replica = this.replica
 
-    end () {
-      removefromList(this)
+    if (this.replica) {
+      this.replica = null
+      replica.end()
     }
+  }
+
+  function Replica (tracker) {
+    const main = hashring.lookup(tracker.key)
+
+    this.key = getNextPoint(tracker.key, main.points)
+    this.tracker = tracker
+    this.list = addToList(this)
+    this.peer = hashring.next(tracker.key)
+  }
+
+  Replica.prototype.end = function () {
+    removefromList(this)
   }
 
   return {

--- a/test/helper.js
+++ b/test/helper.js
@@ -19,6 +19,7 @@ function opts (opts) {
   opts = opts || {}
   opts.hashring = opts.hashring || {}
   opts.hashring.joinTimeout = 200
+  opts.hashring.replicaPoints = 10
   return opts
 }
 

--- a/test/ring-track-replica.test.js
+++ b/test/ring-track-replica.test.js
@@ -40,17 +40,18 @@ boot(t, (one) => {
     // now key will be allocated between the two
     // let's track it
     one.track(key, { replica: true })
-      .on('move', function (newPeer) {
+      .once('move', function (newPeer) {
         t.equal(two.whoami(), newPeer.id, 'destination id matches')
       })
       .on('replica', function () {
-        t.fail('no replica')
+        t.fail('no replica event')
       })
 
-    two.track(key, { replica: true }).on('replica', function (newPeer, oldPeer) {
-      t.equal(one.whoami(), newPeer.id, 'replica id matches')
-      t.notOk(oldPeer, 'no older replica')
-    })
+    two.track(key, { replica: true })
+      .on('replica', function (newPeer, oldPeer) {
+        t.equal(one.whoami(), newPeer.id, 'replica id matches')
+        t.notOk(oldPeer, 'no older replica')
+      })
 
     // let's join them in a cluster
     one.join([two.whoami()], function (err) {

--- a/test/ring-track-replica.test.js
+++ b/test/ring-track-replica.test.js
@@ -40,7 +40,7 @@ boot(t, (one) => {
     // now key will be allocated between the two
     // let's track it
     one.track(key, { replica: true })
-      .on('moved', function (newPeer) {
+      .on('move', function (newPeer) {
         t.equal(two.whoami(), newPeer.id, 'destination id matches')
       })
       .on('replica', function () {

--- a/test/ring-track.test.js
+++ b/test/ring-track.test.js
@@ -40,8 +40,8 @@ boot(t, (one) => {
     // now key will be allocated between the two
     // let's track it
     one.track(key)
-      .on('moved', function () {
-        t.pass('moved')
+      .on('move', function () {
+        t.pass('move')
       })
       .on('replica', function () {
         t.fail('no replica events')

--- a/test/ring-track.test.js
+++ b/test/ring-track.test.js
@@ -39,7 +39,7 @@ boot(t, (one) => {
 
     // now key will be allocated between the two
     // let's track it
-    one.track(key, function () {
+    one.track(key).on('moved', function () {
       t.pass('moved')
     })
 

--- a/test/tracker.test.js
+++ b/test/tracker.test.js
@@ -15,7 +15,7 @@ test('track a value on the ring', (t) => {
   const peer = { id: 'localhost:12345' }
 
   const track = instance.track('hello')
-  track.on('moved', (newPeer) => {
+  track.on('move', (newPeer) => {
     t.equal(newPeer, peer, 'peer is set')
   })
 
@@ -34,7 +34,7 @@ test('do nothing if the element interval is before', (t) => {
 
   const peer = { id: 'localhost:12345' }
 
-  instance.track('hello').on('moved', () => {
+  instance.track('hello').on('move', () => {
     t.fail('this should not be called')
   })
 
@@ -55,7 +55,7 @@ test('do nothing if the element interval is after', (t) => {
 
   const peer = { id: 'localhost:12345' }
 
-  instance.track('hello').on('moved', () => {
+  instance.track('hello').on('move', () => {
     t.fail('this should not be called')
   })
 
@@ -92,7 +92,7 @@ test('call a callback only once', (t) => {
 
   const peer = { id: 'localhost:12345' }
 
-  instance.track('hello').on('moved', (newPeer) => {
+  instance.track('hello').on('move', (newPeer) => {
     t.equal(newPeer, peer, 'peer is set')
   })
 
@@ -121,11 +121,11 @@ test('track two entities', (t) => {
 
   const peer = { id: 'localhost:12345' }
 
-  instance.track('hello').on('moved', (newPeer) => {
+  instance.track('hello').on('move', (newPeer) => {
     t.equal(newPeer, peer, 'peer is set')
   })
 
-  instance.track('hello').on('moved', (newPeer) => {
+  instance.track('hello').on('move', (newPeer) => {
     t.equal(newPeer, peer, 'peer is set')
   })
 
@@ -144,11 +144,11 @@ test('clear()', (t) => {
     allocatedToMe: () => true
   })
 
-  instance.track('hello').on('moved', (newPeer) => {
+  instance.track('hello').on('move', (newPeer) => {
     t.notOk(newPeer, 'newPeer is null')
   })
 
-  instance.track('hello').on('moved', (newPeer) => {
+  instance.track('hello').on('move', (newPeer) => {
     t.notOk(newPeer, 'newPeer is null')
   })
 
@@ -163,7 +163,7 @@ test('do nothing if the the tracker.end function is called', (t) => {
 
   const peer = { id: 'localhost:12345' }
 
-  const track = instance.track('hello').on('moved', () => {
+  const track = instance.track('hello').on('move', () => {
     t.fail('this should not be called')
   })
 

--- a/test/tracker.test.js
+++ b/test/tracker.test.js
@@ -242,16 +242,16 @@ test('track the replica of a value across the ring', (t) => {
   }
 
   const track = instance.track('hello', { replica: true })
-  track.once('changeReplica', (newPeer, oldPeer) => {
+  track.once('replica', (newPeer, oldPeer) => {
     t.equal(newPeer, peer, 'peer is set')
     t.notOk(oldPeer, 'no old peer')
 
-    track.once('changeReplica', (newPeer2, oldPeer2) => {
+    track.once('replica', (newPeer2, oldPeer2) => {
       t.equal(oldPeer2, newPeer, 'peer is set')
       t.equal(newPeer2, peer2)
 
-      track.once('changeReplica', () => {
-        t.fail('no more changeReplica')
+      track.once('replica', () => {
+        t.fail('no more replica')
       })
     })
 


### PR DESCRIPTION
The API of `track()` changes so that it returns an `EventEmitter`, and it emits two events, `'move'` and `'replica'`. 